### PR TITLE
fix(tree):support custom range compare root

### DIFF
--- a/src/avl-tree.js
+++ b/src/avl-tree.js
@@ -212,7 +212,7 @@ AvlTree.prototype.get = function (key) {
  * @return {Object} The node or null if it doesn't exist.
  */
 AvlTree.prototype._get = function (key, root) {
-  if (key === root.key) {
+  if (this._compare(key, root.key) === 0) {
     return root;
   }
 

--- a/test/custom-compare-test.js
+++ b/test/custom-compare-test.js
@@ -17,3 +17,26 @@ test('should function correctly given a non-reverse customCompare', function (t)
   t.is(tree._root.left, null);
   t.is(tree._root.right.key, 1);
 });
+
+test('should function correctly given a non-reverse rangeCompare', function (t) {
+  const tree = new Tree((a, b) => {
+    let result = 0;
+    if (
+      (a.end <= b.end && a.start >= b.start) ||
+      (b.end <= a.end && b.start >= a.start)
+    ) {
+      result = 0;
+    }
+    if (a.end > b.end) {
+      result = 1;
+    }
+    if (a.start < b.start) {
+      result = -1;
+    }
+    return result;
+  });
+  tree.insert({start: 16777472, end: 16778239});
+  tree.insert({start: 16779264, end: 16781311});
+  t.true(tree.contains({start: 16777473, end: 16777473}));
+  t.false(tree.contains({start: 16781312, end: 16781312}));
+});

--- a/test/custom-compare-test.js
+++ b/test/custom-compare-test.js
@@ -18,25 +18,11 @@ test('should function correctly given a non-reverse customCompare', function (t)
   t.is(tree._root.right.key, 1);
 });
 
-test('should function correctly given a non-reverse rangeCompare', function (t) {
+test('should work when the key is a complex object', function (t) {
   const tree = new Tree((a, b) => {
-    let result = 0;
-    if (
-      (a.end <= b.end && a.start >= b.start) ||
-      (b.end <= a.end && b.start >= a.start)
-    ) {
-      result = 0;
-    }
-    if (a.end > b.end) {
-      result = 1;
-    }
-    if (a.start < b.start) {
-      result = -1;
-    }
-    return result;
+    return a.innerKey - b.innerKey;
   });
-  tree.insert({start: 16777472, end: 16778239});
-  tree.insert({start: 16779264, end: 16781311});
-  t.true(tree.contains({start: 16777473, end: 16777473}));
-  t.false(tree.contains({start: 16781312, end: 16781312}));
+  tree.insert({innerKey: 1});
+  t.true(tree.contains({innerKey: 1}));
+  t.false(tree.contains({innerKey: 2}));
 });


### PR DESCRIPTION
use compare function instead of compare directly when key type is not primitive